### PR TITLE
Implement Redis queue for async sentence enrichment

### DIFF
--- a/libs/sentence_queue_utils.py
+++ b/libs/sentence_queue_utils.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2024 Sebastien CHRISTIAN, University of French Polynesia
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Utilities for queuing sentence augmentation tasks using Redis RQ."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict
+
+from redis import Redis
+from rq import Queue
+
+from libs import semantic_description_utils as sdu
+
+# Default Redis connection details
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+QUEUE_NAME = os.getenv("QUEUE_NAME", "sentence")
+
+
+def _process_sentence_pair(sentence_pair: Dict, output_file: str) -> Dict:
+    """Worker task to enrich a sentence pair and append it to a JSONL file."""
+    result = sdu.add_description_and_keywords_to_sentence_pair(sentence_pair)
+    if result is not None:
+        with open(output_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(result, ensure_ascii=False) + "\n")
+    return result
+
+
+def enqueue_sentence_pair(sentence_pair: Dict, output_file: str) -> str:
+    """Enqueue a sentence pair for processing.
+
+    Parameters
+    ----------
+    sentence_pair : dict
+        Source/target sentence pair.
+    output_file : str
+        Path to the JSONL file where results will be appended.
+
+    Returns
+    -------
+    str
+        The job ID for tracking.
+    """
+    redis_conn = Redis.from_url(REDIS_URL)
+    q = Queue(QUEUE_NAME, connection=redis_conn)
+    job = q.enqueue(_process_sentence_pair, sentence_pair, output_file)
+    return job.id

--- a/requirements.txt
+++ b/requirements.txt
@@ -146,3 +146,5 @@ wcwidth==0.2.13
 weasel==0.4.1
 wrapt==1.17.2
 zipp==3.17.0
+redis==5.0.4
+rq==1.17

--- a/rq_worker.py
+++ b/rq_worker.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2024 Sebastien CHRISTIAN, University of French Polynesia
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#!/usr/bin/env python
+"""RQ worker to process sentence augmentation tasks."""
+
+from redis import Redis
+from rq import Worker, Queue, Connection
+import os
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+QUEUE_NAME = os.getenv("QUEUE_NAME", "sentence")
+
+
+def main() -> None:
+    redis_conn = Redis.from_url(REDIS_URL)
+    with Connection(redis_conn):
+        worker = Worker([QUEUE_NAME])
+        worker.work()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- queue sentence pair processing via Redis RQ
- append results to a JSONL file as jobs finish
- add helper worker script and queue utilities
- support JSONL inputs/outputs in the Streamlit page
- add `redis` and `rq` to requirements

## Testing
- `python3 -m py_compile libs/sentence_queue_utils.py rq_worker.py pages/sentence_retrieval_test.py`


------
https://chatgpt.com/codex/tasks/task_e_687fff5571f4832d9cf24015ce9224cb