### PR TITLE
Fix missing RQ worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: streamlit run home.py --server.port $PORT --server.headless true
+worker: python rq_worker.py


### PR DESCRIPTION
## Summary
- add a worker process to the `Procfile` so queued jobs run

## Testing
- `pytest -q` *(fails: pyenv version `3.10.10` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68800e176e70832db6521cdbec625a35