### PR TITLE
Ensure UTF-8 JSON output

### DIFF
--- a/libs/grambank_utils.py
+++ b/libs/grambank_utils.py
@@ -66,7 +66,7 @@ def build_vname_by_vid():
         for vid, valueinfo in grambank_param_value_dict[pid]["pvalues"].items():
             grambank_vname_by_vid[vid] = valueinfo["vname"]
     with open("../external_data/grambank_derived/grambank_vname_by_vid.json", "w") as f:
-        json.dump(grambank_vname_by_vid, f, indent=4)
+        json.dump(grambank_vname_by_vid, f, ensure_ascii=False, indent=4)
 
 
 def get_grambank_language_data_by_id_or_name(language_id, language_name=None):
@@ -311,7 +311,7 @@ def build_grambank_pvalues_by_language():
             grambank_pvalues_by_language[item["Language_ID"]].append(item["Code_ID"])
     print("grambank_pvalues_by_language built, {} data points.".format(entry_count))
     with open("../external_data/grambank_derived/grambank_pvalues_by_language.json", "w") as f:
-        json.dump(grambank_pvalues_by_language, f, indent=4)
+        json.dump(grambank_pvalues_by_language, f, ensure_ascii=False, indent=4)
 
 
 def build_grambank_language_id_by_vid():
@@ -327,7 +327,7 @@ def build_grambank_language_id_by_vid():
             grambank_language_id_by_vid[item["Code_ID"]].append(item["Language_ID"])
     print("grambank_language_id_by_pvalue_id built, {} data points.".format(entry_count))
     with open("../external_data/grambank_derived/grambank_language_id_by_vid.json", "w") as f:
-        json.dump(grambank_language_id_by_vid, f, indent=4)
+        json.dump(grambank_language_id_by_vid, f, ensure_ascii=False, indent=4)
 
 
 def build_grambank_language_by_lid():
@@ -344,7 +344,7 @@ def build_grambank_language_by_lid():
             "macroarea": item["Macroarea"]
         }
     with open("../external_data/grambank_derived/language_by_lid.json", "w") as f:
-        json.dump(language_by_lid, f, indent=4)
+        json.dump(language_by_lid, f, ensure_ascii=False, indent=4)
 
 
 def build_grambank_pname_by_pid():
@@ -358,9 +358,9 @@ def build_grambank_pname_by_pid():
             grambank_pname_by_pid[param["ID"]] = param["Name"]
             grambank_pid_by_pname[param["Name"]] = param["ID"]
     with open("../external_data/grambank_derived/grambank_pname_by_pid.json", "w") as f:
-        json.dump(grambank_pname_by_pid, f, indent=4)
+        json.dump(grambank_pname_by_pid, f, ensure_ascii=False, indent=4)
     with open("../external_data/grambank_derived/grambank_pid_by_pname.json", "w") as f:
-        json.dump(grambank_pid_by_pname, f, indent=4)
+        json.dump(grambank_pid_by_pname, f, ensure_ascii=False, indent=4)
 
 
 def build_grambank_param_value_dict():
@@ -389,7 +389,7 @@ def build_grambank_param_value_dict():
                 }
             }
     with open("../external_data/grambank_derived/grambank_param_value_dict.json", "w") as f:
-        json.dump(grambank_param_value_dict, f, indent=4)
+        json.dump(grambank_param_value_dict, f, ensure_ascii=False, indent=4)
         
         
 def build_pid_by_vid():
@@ -400,7 +400,7 @@ def build_pid_by_vid():
     for item in items:
         pid_by_vid[item["ID"]] = item["Parameter_ID"]
     with open("../external_data/grambank_derived/parameter_id_by_value_id.json", "w") as f:
-        json.dump(pid_by_vid, f, indent=4)
+        json.dump(pid_by_vid, f, ensure_ascii=False, indent=4)
 
 
 def build_vids_by_lid():
@@ -414,7 +414,7 @@ def build_vids_by_lid():
         else:
             vids_by_lid[item["Language_ID"]] = [item["Code_ID"]]
     with open("../external_data/grambank_derived/pvalue_ids_by_language_id.json", "w") as f:
-        json.dump(vids_by_lid, f, indent=4)
+        json.dump(vids_by_lid, f, ensure_ascii=False, indent=4)
 
 
 def build_lid_by_family():
@@ -425,4 +425,4 @@ def build_lid_by_family():
         else:
             lid_by_family[ldata["family"]].append(lid)
     with open("../external_data/grambank_derived/lid_by_family.json", "w") as f:
-        json.dump(lid_by_family, f, indent=4)
+        json.dump(lid_by_family, f, ensure_ascii=False, indent=4)

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -46,11 +46,13 @@ def normalize_user_strings(obj):
 
 def save_json_normalized(data, fp, *args, **kwargs):
     """Wrapper around :func:`json.dump` that normalizes strings before saving."""
+    kwargs.setdefault("ensure_ascii", False)
     json.dump(normalize_user_strings(data), fp, *args, **kwargs)
 
 
 def dumps_json_normalized(data, *args, **kwargs):
     """Wrapper around :func:`json.dumps` that normalizes strings before serializing."""
+    kwargs.setdefault("ensure_ascii", False)
     return json.dumps(normalize_user_strings(data), *args, **kwargs)
 
 
@@ -169,7 +171,7 @@ def add_field_to_concept_json(concept_json_file, field_name, field_value):
     for concept in data.keys():
         data[concept][field_name] = field_value
     with open(concept_json_file, "w") as f:
-        json.dump(data, f, indent=4)
+        json.dump(data, f, ensure_ascii=False, indent=4)
     print(f"Field {field_name} added to {concept_json_file}")
 
 def get_key_by_value(d, target_value):

--- a/libs/wals_utils.py
+++ b/libs/wals_utils.py
@@ -126,7 +126,7 @@ def build_language_pk_by_id():
         except KeyError:
             print("no id field in language pk {}".format(lpk))
     with open("../external_data/wals_derived/language_pk_by_id.json", "w") as f:
-        json.dump(language_pk_by_id, f, indent=4)
+        json.dump(language_pk_by_id, f, ensure_ascii=False, indent=4)
 
 
 def build_param_pk_by_de_pk():
@@ -137,7 +137,7 @@ def build_param_pk_by_de_pk():
             if depk not in param_pk_by_de_pk.keys():
                 param_pk_by_de_pk[depk] = ppk
     with open("../external_data/wals_derived/param_pk_by_de_pk.json", "w") as f:
-        json.dump(param_pk_by_de_pk, f, indent=4)
+        json.dump(param_pk_by_de_pk, f, ensure_ascii=False, indent=4)
 
 def build_param_name_by_de_name():
     param_name_by_de_name = {}
@@ -146,7 +146,7 @@ def build_param_name_by_de_name():
         p_name = parameter_name_by_pk[str(ppk)]
         param_name_by_de_name[info["name"]] = p_name
     with open("../external_data/wals_derived/param_name_by_de_name.json", "w") as f:
-        json.dump(param_name_by_de_name, f, indent=4)
+        json.dump(param_name_by_de_name, f, ensure_ascii=False, indent=4)
 
 def build_params_pk_by_language_pk():
     params_pk_by_language_pk = {}
@@ -160,7 +160,7 @@ def build_params_pk_by_language_pk():
             else:
                 print("build_params_pk_by_language_pk: {} not in param_pk_by_de_pk".format(depk))
     with open("../external_data/wals_derived/params_pk_by_language_pk.json", "w") as f:
-        json.dump(params_pk_by_language_pk, f, indent=4)
+        json.dump(params_pk_by_language_pk, f, ensure_ascii=False, indent=4)
 
 
 def get_careful_name_of_de_pk(depk):
@@ -310,7 +310,7 @@ def build_number_of_params_by_language_id():
         out_dict[id] = n_param
         print("{} / {}".format(c, n))
     with open("./external_data/wals_derived/n_param_by_language_id.json", "w") as f:
-        json.dump(out_dict, f)
+        json.dump(out_dict, f, ensure_ascii=False)
 
 def build_domain_elements_by_language_and_languages_by_domain_element():
     with open("./external_data/wals_derived/language_by_pk_lookup_table.json") as f:
@@ -336,9 +336,9 @@ def build_domain_elements_by_language_and_languages_by_domain_element():
         except:
             print("issue with a result dict on language {}".format(language_id))
     with open("./external_data/wals_derived/domain_elements_by_language.json", "w") as f:
-        json.dump(domain_elements_by_language, f)
+        json.dump(domain_elements_by_language, f, ensure_ascii=False)
     with open("./external_data/wals_derived/languages_by_domain_element.json", "w") as f:
-        json.dump(languages_by_domain_element, f)
+        json.dump(languages_by_domain_element, f, ensure_ascii=False)
 
 #  ================ COMPUTING AND STORING CONDITIONAL PROBABILITY TABLE ========
 
@@ -712,7 +712,7 @@ def get_available_wals_languages_dict():
             "id": language_by_pk_lookup_table[lpk]["id"]
         }
     with open("./external_data/wals_derived/language_pk_id_by_name.json", "w") as f:
-        json.dump(language_dict, f)
+        json.dump(language_dict, f, ensure_ascii=False)
     return language_dict
 
 def get_wals_language_data_by_id_or_name(language_id, language_name=None):
@@ -793,7 +793,7 @@ def build_parameter_pk_by_name_lookup_table():
         parameter_pk_by_name_lookup_table[entry["name"]] = str(entry["pk"])
     # store the lookup table in a file
     with open("../external_data/wals_derived/parameter_pk_by_name_lookup_table.json", "w") as f:
-        json.dump(parameter_pk_by_name_lookup_table, f)
+        json.dump(parameter_pk_by_name_lookup_table, f, ensure_ascii=False)
     return parameter_pk_by_name_lookup_table
 
 def load_parameter_pk_by_name_lookup_table():
@@ -815,7 +815,7 @@ def build_domain_elements_pk_by_parameter_pk_lookup_table():
             domain_elements_pk_by_parameter_pk_lookup_table[entry["parameter_pk"]].append(str(entry["pk"]))
     # store the lookup table in a file
     with open("../external_data/wals_derived/domain_elements_pk_by_parameter_pk_lookup_table.json", "w") as f:
-        json.dump(domain_elements_pk_by_parameter_pk_lookup_table, f)
+        json.dump(domain_elements_pk_by_parameter_pk_lookup_table, f, ensure_ascii=False)
     return domain_elements_pk_by_parameter_pk_lookup_table
 
 def load_domain_elements_pk_by_parameter_pk_lookup_table():
@@ -837,7 +837,7 @@ def build_domain_element_by_pk_lookup_table():
             domain_element_by_pk_lookup_table[entry["pk"]].append(entry)
     # store the lookup table in a file
     with open("./external_data/wals_derived/domain_element_by_pk_lookup_table.json", "w") as f:
-        json.dump(domain_element_by_pk_lookup_table, f)
+        json.dump(domain_element_by_pk_lookup_table, f, ensure_ascii=False)
     return domain_element_by_pk_lookup_table
 
 def load_domain_element_by_pk_lookup_table():
@@ -859,7 +859,7 @@ def build_value_by_domain_element_pk_lookup_table():
             value_by_domain_element_pk_lookup_table[value["domainelement_pk"]].append(value)
     # store the lookup table in a file
     with open("./external_data/wals_derived/value_by_domain_element_pk_lookup_table.json", "w") as f:
-        json.dump(value_by_domain_element_pk_lookup_table, f)
+        json.dump(value_by_domain_element_pk_lookup_table, f, ensure_ascii=False)
     return value_by_domain_element_pk_lookup_table
 
 def load_value_by_domain_element_pk_lookup_table():
@@ -878,7 +878,7 @@ def build_valueset_by_pk_lookup_table():
         valueset_by_pk_lookup_table[v["pk"]] = v
     # store the lookup table in a file
     with open("./external_data/wals_derived/valueset_by_pk_lookup_table.json", "w") as f:
-        json.dump(valueset_by_pk_lookup_table, f)
+        json.dump(valueset_by_pk_lookup_table, f, ensure_ascii=False)
     return valueset_by_pk_lookup_table
 
 def load_valueset_by_pk_lookup_table():
@@ -897,7 +897,7 @@ def build_language_by_pk_lookup_table():
         language_by_pk_lookup_table[l["pk"]] = l
     # store the lookup table in a file
     with open("./external_data/wals_derived/language_by_pk_lookup_table.json", "w") as f:
-        json.dump(language_by_pk_lookup_table, f)
+        json.dump(language_by_pk_lookup_table, f, ensure_ascii=False)
     return language_by_pk_lookup_table
 
 def load_language_by_pk_lookup_table():
@@ -922,7 +922,7 @@ def build_language_info_by_id_lookup_table():
         }
     # store the lookup table in a file
     with open("./external_data/wals_derived/language_info_by_id_lookup_table.json", "w") as f:
-        json.dump(language_info_by_id_lookup_table, f)
+        json.dump(language_info_by_id_lookup_table, f, ensure_ascii=False)
     return language_info_by_id_lookup_table
 
 def load_language_info_by_id_lookup_table():
@@ -948,7 +948,7 @@ def update_delimiter_file():
         if language_name not in delimiters.keys():
             delimiters[language_name] = [" ", ".", ",", ";", ":", "!", "?", "…", "'"]
     with open("./data/delimiters.json", "w") as f:
-        json.dump(delimiters, f)
+        json.dump(delimiters, f, ensure_ascii=False)
 
 def build_domain_elements_pk_by_parameter_pk_lookup_table_filtered():
     """creates the reduced domain_element_by_pk json based on a limited list of paramaters"""
@@ -973,7 +973,7 @@ def build_domain_elements_pk_by_parameter_pk_lookup_table_filtered():
             print("{} not in domain_elements_pk_by_parameter_pk".format(param_pk))
 
     with open("./external_data/wals_derived/domain_element_by_pk_lookup_table_filtered.json", "w") as f:
-        json.dump(filtered_de, f)
+        json.dump(filtered_de, f, ensure_ascii=False)
 
 def build_language_pk_by_family_subfamily_genus_macroarea():
     with open("./external_data/wals_derived/language_info_by_id_lookup_table.json") as f:
@@ -1024,10 +1024,10 @@ def build_language_pk_by_family_subfamily_genus_macroarea():
             print("{} not in language_pk_by_id")
 
     with open("./external_data/wals_derived/language_pk_by_family.json", "w") as f:
-        json.dump(language_pk_by_family, f)
+        json.dump(language_pk_by_family, f, ensure_ascii=False)
     with open("./external_data/wals_derived/language_pk_by_subfamily.json", "w") as f:
-        json.dump(language_pk_by_subfamily, f)
+        json.dump(language_pk_by_subfamily, f, ensure_ascii=False)
     with open("./external_data/wals_derived/language_pk_by_genus.json", "w") as f:
-        json.dump(language_pk_by_genus, f)
+        json.dump(language_pk_by_genus, f, ensure_ascii=False)
     with open("./external_data/wals_derived/language_pk_by_macroarea.json", "w") as f:
-        json.dump(language_pk_by_macroarea, f)
+        json.dump(language_pk_by_macroarea, f, ensure_ascii=False)

--- a/pages/4_CQ Editor.py
+++ b/pages/4_CQ Editor.py
@@ -388,7 +388,7 @@ with colz.container():
         #print(st.session_state["cq"]["dialog"][str(st.session_state["counter"])])
         st.rerun()
 
-    coli.download_button(label="download your Conversational Questionnaire", data=json.dumps(st.session_state["cq"], indent=4),
+    coli.download_button(label="download your Conversational Questionnaire", data=json.dumps(st.session_state["cq"], ensure_ascii=False, indent=4),
                        file_name="cq_" + st.session_state["cq"]["title"] + "_" + st.session_state["uid"] + ".json")
 
     if colo.button("Reset sentence"):

--- a/pages/Concept_graph_editor.py
+++ b/pages/Concept_graph_editor.py
@@ -36,7 +36,7 @@ if "concepts_kson" not in st.session_state:
 print("PAGE RELOAD")
 print("focus: {}".format(st.session_state["focus"]))
 
-st.download_button(label="download your Concept Graph", data=json.dumps(st.session_state["concepts_kson"], indent=4),
+st.download_button(label="download your Concept Graph", data=json.dumps(st.session_state["concepts_kson"], ensure_ascii=False, indent=4),
                        file_name="cg_.json")
 
 def on_focus_change():

--- a/pages/Testing_general_agents.py
+++ b/pages/Testing_general_agents.py
@@ -431,16 +431,16 @@ if len(st.session_state["ga_domains"]) > 0:
                 st.write("**Consensus accuracy on unknown values by language.**")
                 st.bar_chart(pd.DataFrame(scoring_table).T)
 
-                st.download_button("Download scoring table", json.dumps(scoring_table, indent=4),
-                                   file_name="scoring_table.json")
+                st.download_button("Download scoring table", json.dumps(scoring_table, ensure_ascii=False, indent=4),
+                                    file_name="scoring_table.json")
 
                 st.write("**Truth table of consensus on unknown values by language.**")
                 st.table(truth_table)
-                st.download_button("Download truth table", json.dumps(truth_table, indent=4),
-                                   file_name="truth_table.json")
+                st.download_button("Download truth table", json.dumps(truth_table, ensure_ascii=False, indent=4),
+                                    file_name="truth_table.json")
 
                 with open("./data/binary_truth_table_tmp.json", "w") as f:
-                    json.dump(binary_truth_table, f)
+                    json.dump(binary_truth_table, f, ensure_ascii=False)
                 st.write("**detailed consensus by language**")
                 st.table(general_result_dict)
 else:

--- a/pages/Transcriptions_explorer.py
+++ b/pages/Transcriptions_explorer.py
@@ -216,7 +216,7 @@ with st.expander("Input", expanded=True):
                                                                                    include_particularization=st.session_state["include_particularization"],
                                                                                    keep_target_words=st.session_state["keep_target_words"])
                 with open("./data/knowledge/current_kg.json", "w") as f:
-                    json.dump(st.session_state["knowledge_graph"], f, indent=4)
+                    json.dump(st.session_state["knowledge_graph"], f, ensure_ascii=False, indent=4)
                 st.write("{} Conversational Questionnaires: {} sentences, {} words with {} unique words".format(
                     len(st.session_state["cq_transcriptions"]), len(st.session_state["knowledge_graph"]),
                     total_target_word_count, len(unique_words)))
@@ -254,7 +254,7 @@ with st.expander("Input", expanded=True):
                                                                                    include_particularization=st.session_state["include_particularization"],
                                                                                    keep_target_words=st.session_state["keep_target_words"])
                 with open("./data/knowledge/current_kg.json", "w") as f:
-                    json.dump(st.session_state["knowledge_graph"], f, indent=4)
+                    json.dump(st.session_state["knowledge_graph"], f, ensure_ascii=False, indent=4)
                 st.write("{} Conversational Questionnaires: {} sentences, {} words with {} unique words".format(
                     len(st.session_state["cq_transcriptions"]), len(st.session_state["knowledge_graph"]),
                     total_target_word_count, len(unique_words)))

--- a/pages/generate_grammar.py
+++ b/pages/generate_grammar.py
@@ -243,12 +243,12 @@ if (st.session_state.alterlingua_contribution
 
         if st.session_state.is_cq and st.session_state.use_cq:
             tmp_p_blob = json.dumps([p for p in st.session_state.cq_knowledge["grammar_priors"]
-                                     if p["Parameter"] in st.session_state.relevant_parameters])
+                                     if p["Parameter"] in st.session_state.relevant_parameters], ensure_ascii=False)
             if tmp_p_blob == "":
                 tmp_p_blob = "No relevant grammatical parameter."
             selected_params_blob = tmp_p_blob
             alterlingua_explanation = st.session_state.alterlingua_contribution["explanation"]
-            alterlingua_examples = json.dumps(st.session_state.alterlingua_contribution["examples"])
+            alterlingua_examples = json.dumps(st.session_state.alterlingua_contribution["examples"], ensure_ascii=False)
         else:
             selected_params_blob = "No relevant grammatical parameter."
             alterlingua_explanation = "No description from sentence analysis."
@@ -275,7 +275,7 @@ if (st.session_state.alterlingua_contribution
                     }
 
                 sps.append(sapd)
-            sentence_pairs_blob = json.dumps(sps)
+            sentence_pairs_blob = json.dumps(sps, ensure_ascii=False)
         else:
             sentence_pairs_blob = "No available sentence pairs."
 
@@ -327,7 +327,7 @@ if st.session_state.output_dict:
     if st.button("Store output (and share it with others)"):
 
         with open(os.path.join(BASE_LD_PATH, st.session_state.indi, "outputs", fn), "w") as f:
-            json.dump(st.session_state.output_dict, f)
+            json.dump(st.session_state.output_dict, f, ensure_ascii=False)
         if docx:
             with open(os.path.join(BASE_LD_PATH, st.session_state.indi, "outputs", fn[:-5]+".docx"), "wb") as f:
                 f.write(docx.getvalue())
@@ -335,13 +335,13 @@ if st.session_state.output_dict:
             info = json.load(f)
         info["outputs"][query] = fn
         with open(os.path.join(BASE_LD_PATH, st.session_state.indi, "info.json"), "w") as f:
-            info = json.dump(info, f)
+            json.dump(info, f, ensure_ascii=False)
         st.success("Output stored and available")
 
     # Download outputs
     colz, colx = st.columns(2)
     colz.download_button(label="Download JSON output",
-                         data=json.dumps(st.session_state.output_dict),
+                         data=json.dumps(st.session_state.output_dict, ensure_ascii=False),
                          file_name=fn)
     if docx:
         colx.download_button(label="Download DOCX output",

--- a/script/deepl_translate.py
+++ b/script/deepl_translate.py
@@ -9,7 +9,7 @@ def create_eng_corpus_from_kg_file():
     for index, data in kg.items():
         corpus.append(data["sentence_data"]["text"])
     with open("../data/embeddings/corpus_single_eng.json", "w") as f:
-        json.dump(corpus, f, indent=4)
+        json.dump(corpus, f, ensure_ascii=False, indent=4)
     return corpus
 
 def create_target_corpus_from_kg_file():
@@ -19,7 +19,7 @@ def create_target_corpus_from_kg_file():
     for index, data in kg.items():
         corpus.append(data["recording_data"]["translation"])
     with open("../data/embeddings/corpus_single_target.json", "w") as f:
-        json.dump(corpus, f, indent=4)
+        json.dump(corpus, f, ensure_ascii=False, indent=4)
     return corpus
 
 
@@ -48,9 +48,9 @@ for target_language in target_lang_list:
     print("translation done for {}".format(target_language))
     print("{} sentences translated, {} character translated.".format(len(corpus[target_language]), n_char))
     with open(f"../data/embeddings/corpus_adding_{target_language}.json", "w") as f:
-        json.dump(corpus, f, indent=4)
+        json.dump(corpus, f, ensure_ascii=False, indent=4)
     print(f"../data/embeddings/corpus_adding_{target_language}.json file saved")
 
 with open("../data/embeddings/corpus_deepl.json", "w") as f:
-    json.dump(corpus, f, indent=4)
+    json.dump(corpus, f, ensure_ascii=False, indent=4)
 

--- a/script/flex_viewer.py
+++ b/script/flex_viewer.py
@@ -70,7 +70,7 @@ if uploaded_file:
     st.session_state.sentence_pairs = _convert_to_sentence_pairs(parsed_data)
     if st.session_state.sentence_pairs:
         st.download_button("Download sentence pairs",
-                           data=json.dumps(st.session_state.sentence_pairs),
+                           data=json.dumps(st.session_state.sentence_pairs, ensure_ascii=False),
                            file_name="sentence_pairs_from_flex.json",
                            mime="application/json"
                            )

--- a/script/general_agents_full_test_word_order.py
+++ b/script/general_agents_full_test_word_order.py
@@ -181,7 +181,7 @@ def process_excluded_language(excluded_lid: str):
         average_score = average_score / len(general_result_dict)
 
         with open("../test_results/truth_table_{}_excluded_epoch_{}.json".format(excluded_lid, epoch), "w") as f:
-            json.dump(truth_table, f)
+            json.dump(truth_table, f, ensure_ascii=False)
 
 # RESULT ANALYSIS =======================================================================================
 def analyze_results():

--- a/script/general_agents_quantitative_comparative_analysis.py
+++ b/script/general_agents_quantitative_comparative_analysis.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
             out_list = pool.map(create_naive_vs_dig4el_accuracy_list, test_data)
 
         with open("../test_result_analysis/summaries/comparative_results_baseline_vs_dig4el.json", "w") as f:
-            json.dump(out_list, f)
+            json.dump(out_list, f, ensure_ascii=False)
     if ANALYZE:
         def bootstrap_ci(data, func=np.mean, n_bootstrap=10000, ci=95):
             rng = np.random.default_rng(seed=42)


### PR DESCRIPTION
## Summary
- Default to UTF-8 when dumping JSON in utility helpers
- Preserve non-ASCII text in various scripts and Streamlit pages by passing `ensure_ascii=False`

## Testing
- `pytest` *(fails: pyenv version `3.10.10` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689e5f9dead8832db92fdcc079895212